### PR TITLE
アップロードファイル名の表示対応

### DIFF
--- a/chatmessageview/build.gradle
+++ b/chatmessageview/build.gradle
@@ -2,10 +2,11 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.3"
 
     defaultConfig {
         minSdkVersion 15
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 24
         versionCode 1
         versionName "1.3.3"
@@ -82,6 +83,7 @@ install {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
+    //noinspection GradleCompatible
     compile 'com.android.support:appcompat-v7:24.1.1'
     compile 'de.hdodenhof:circleimageview:2.1.0'
     compile 'com.android.support:support-v4:24.2.1'

--- a/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/models/Message.java
+++ b/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/models/Message.java
@@ -155,6 +155,9 @@ public class Message {
      */
     private boolean mIsUnreadMarked;
 
+
+    private String mFilename;
+
     /**
      * Message Types
      *
@@ -231,6 +234,11 @@ public class Message {
 
         public Builder setMessageText(String messageText) {
             message.setMessageText(messageText);
+            return this;
+        }
+
+        public Builder setFilename(String filename) {
+            message.setFilename(filename);
             return this;
         }
 
@@ -359,6 +367,14 @@ public class Message {
 
     public void setMessageText(String messageText) {
         mMessageText = messageText;
+    }
+
+    public String getFilename() {
+        return mFilename;
+    }
+
+    public void setFilename(String filename) {
+        mFilename = filename;
     }
 
     public Calendar getCreatedAt() {

--- a/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/views/adapters/MessageAdapter.java
+++ b/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/views/adapters/MessageAdapter.java
@@ -194,6 +194,9 @@ public class MessageAdapter extends ArrayAdapter<Object> {
                     View pictureBubble = mLayoutInflater.inflate(R.layout.message_picture_right, holder.mainMessageContainer);
                     holder.messagePicture = (RoundImageView) pictureBubble.findViewById(R.id.message_picture);
                     holder.messagePicture.setImageBitmap(message.getPicture());
+                    // ファイル名をセット
+                    holder.filename = (TextView) convertView.findViewById(R.id.filename);
+                    holder.filename.setText(message.getFilename());
                 } else if (message.getType() == Message.Type.TEXT_EXTENSION) {
                     //Set text
                     View textBubble = mLayoutInflater.inflate(R.layout.message_text_right, holder.mainMessageContainer);
@@ -385,6 +388,9 @@ public class MessageAdapter extends ArrayAdapter<Object> {
                     View pictureBubble = mLayoutInflater.inflate(R.layout.message_picture_left, holder.mainMessageContainer);
                     holder.messagePicture = (RoundImageView) pictureBubble.findViewById(R.id.message_picture);
                     holder.messagePicture.setImageBitmap(message.getPicture());
+                    // ファイル名をセット
+                    holder.filename = (TextView) convertView.findViewById(R.id.filename);
+                    holder.filename.setText(message.getFilename());
                 } else if (message.getType() == Message.Type.TEXT_EXTENSION) {
                     //Set text
                     View textBubble = mLayoutInflater.inflate(R.layout.message_text_left, holder.mainMessageContainer);
@@ -661,6 +667,7 @@ public class MessageAdapter extends ArrayAdapter<Object> {
         FrameLayout statusContainer;
         ImageView statusIcon;
         TextView statusText;
+        TextView filename;
         LinearLayout unreadBorderContainer;
     }
 

--- a/chatmessageview/src/main/res/layout/message_view_left.xml
+++ b/chatmessageview/src/main/res/layout/message_view_left.xml
@@ -53,7 +53,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/spacing_large"
-                android:orientation="horizontal">
+                android:orientation="vertical">
 
                 <FrameLayout
                     android:id="@+id/main_message_container"
@@ -74,13 +74,27 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
 
-                    <TextView
-                        android:id="@+id/time_display_text"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/default_time_text" />
                 </LinearLayout>
             </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:orientation="horizontal">
+                <TextView
+                    android:id="@+id/filename"
+                    android:layout_weight="1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="" />
+                <TextView
+                    android:id="@+id/time_display_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/default_time_text" />
+            </LinearLayout>
+
         </LinearLayout>
     </LinearLayout>
 

--- a/chatmessageview/src/main/res/layout/message_view_right.xml
+++ b/chatmessageview/src/main/res/layout/message_view_right.xml
@@ -72,9 +72,17 @@
                 android:layout_gravity="end"/>
 
             <FrameLayout
+                android:paddingBottom="3dp"
                 android:id="@+id/main_message_container"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
+            <TextView
+                android:id="@+id/filename"
+                android:gravity="right"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="" />
+
 
         </LinearLayout>
 


### PR DESCRIPTION
こちら↓の対応でライブラリ側の対応を行いました
https://github.com/Renoveru/renoveruapp_android/pull/346

- アップロード されたファイルの`ファイル名` を表示
- buildToolsVersion のVerUp(AndroidStudio4でビルドエラーが発生する為)
- minSdkVersion などの警告を除去(`noinspection GradleCompatible` を追加)