### PR TITLE
ファイル名1行対応、テキストのみのレイアウト調整

### DIFF
--- a/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/views/adapters/MessageAdapter.java
+++ b/chatmessageview/src/main/java/com/github/bassaer/chatmessageview/views/adapters/MessageAdapter.java
@@ -209,6 +209,8 @@ public class MessageAdapter extends ArrayAdapter<Object> {
                     //Set message text color
                     holder.messageText.setTextColor(mRightMessageTextColor);
                     holder.messageText.setLinkTextColor(mRightMessageLinkColor);
+                    // 時間位置調整(下マージン)
+                    adjustTimeContainerRight(holder.timeText);
                     //Set link preview
                     for (final LinkData data : message.getLinkDatas()) {
                         View linkView = mLayoutInflater.inflate(R.layout.message_preview_right, null);
@@ -301,6 +303,8 @@ public class MessageAdapter extends ArrayAdapter<Object> {
                     setColorDrawable(mRightBubbleColor, holder.messageTextBubble.getBackground());
                     //Set message text color
                     holder.messageText.setTextColor(mRightMessageTextColor);
+                    // 時間位置調整(下マージン)
+                    adjustTimeContainerRight(holder.timeText);
                 }
 
                 holder.timeText.setText(message.getTimeText());
@@ -403,6 +407,8 @@ public class MessageAdapter extends ArrayAdapter<Object> {
                     //Set message text color
                     holder.messageText.setTextColor(mLeftMessageTextColor);
                     holder.messageText.setLinkTextColor(mLeftMessageLinkColor);
+                    // 時間位置調整(下マージン)
+                    adjustTimeContainerLeft(holder.mainMessageContainer);
                     //Set link preview
                     for (final LinkData data : message.getLinkDatas()) {
                         View linkView = mLayoutInflater.inflate(R.layout.message_preview_left, null);
@@ -495,6 +501,8 @@ public class MessageAdapter extends ArrayAdapter<Object> {
                     setColorDrawable(mLeftBubbleColor, holder.messageTextBubble.getBackground());
                     //Set message text color
                     holder.messageText.setTextColor(mLeftMessageTextColor);
+                    // 時間位置調整(下マージン)
+                    adjustTimeContainerLeft(holder.mainMessageContainer);
                 }
 
                 holder.timeText.setText(message.getTimeText());
@@ -555,6 +563,24 @@ public class MessageAdapter extends ArrayAdapter<Object> {
 
         return convertView;
     }
+
+    /**
+     * 時間コンテナーの位置調整(右)
+     * @param timeText
+     */
+    private void adjustTimeContainerRight(View timeText) {
+        ViewGroup parentTime = (ViewGroup)timeText.getParent();
+        parentTime.setPadding(0,0,0,getContext().getResources().getDimensionPixelSize(R.dimen.spacing_normal));
+    }
+    /**
+     * 時間コンテナーの位置調整(左)
+     * @param msgConatiner
+     */
+    private void adjustTimeContainerLeft(View msgConatiner) {
+        LinearLayout mainMessageParent = (LinearLayout) msgConatiner.getParent();
+        mainMessageParent.setOrientation(LinearLayout.HORIZONTAL);
+    }
+
 
     /**
      * Add color to drawable

--- a/chatmessageview/src/main/res/layout/message_view_left.xml
+++ b/chatmessageview/src/main/res/layout/message_view_left.xml
@@ -62,6 +62,27 @@
                     android:layout_weight="1"/>
 
                 <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/filename"
+                        android:ellipsize="end"
+                        android:singleLine="true"
+                        android:layout_weight="1"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:text="" />
+                    <TextView
+                        android:id="@+id/time_display_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/default_time_text" />
+                </LinearLayout>
+
+
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="bottom"
@@ -76,25 +97,6 @@
 
                 </LinearLayout>
             </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="bottom"
-                android:orientation="horizontal">
-                <TextView
-                    android:id="@+id/filename"
-                    android:layout_weight="1"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="" />
-                <TextView
-                    android:id="@+id/time_display_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/default_time_text" />
-            </LinearLayout>
-
         </LinearLayout>
     </LinearLayout>
 

--- a/chatmessageview/src/main/res/layout/message_view_right.xml
+++ b/chatmessageview/src/main/res/layout/message_view_right.xml
@@ -78,7 +78,10 @@
                 android:layout_height="wrap_content"/>
             <TextView
                 android:id="@+id/filename"
+                android:ellipsize="end"
+                android:singleLine="true"
                 android:gravity="right"
+                android:layout_marginBottom="@dimen/spacing_line"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="" />


### PR DESCRIPTION
こちらの対応になります
[#352](https://github.com/Renoveru/renoveruapp_android/issues/352)
※詳細は 上記に記載致します 🙇 


- ファイル名の1行/省略表示
- テキストのみ時のレイアウト調整
