### PR TITLE
省略記号の横位置調整

### DIFF
--- a/chatmessageview/src/main/res/layout/message_view_left.xml
+++ b/chatmessageview/src/main/res/layout/message_view_left.xml
@@ -113,6 +113,7 @@
                     android:ellipsize="end"
                     android:singleLine="true"
                     android:layout_weight="1"
+                    android:paddingRight="14dp"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:text="" />


### PR DESCRIPTION
メッセージの省略記号について、添付画像幅内に表示されるように調整